### PR TITLE
Implements the Add Address form modal for the Finance page as specified in issue #110.

### DIFF
--- a/src/app/(app)/finance/page.tsx
+++ b/src/app/(app)/finance/page.tsx
@@ -1,7 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import useModal from "@/hooks/useModal";
+import AddAddressModal from "@/components/finance/add-address-modal";
+
 export default function FinancePage() {
+  const { showCustomModal } = useModal();
+
+  useEffect(() => {
+    // Auto-open via query ?openAddAddress=true
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("openAddAddress") === "true") {
+      showCustomModal(<AddAddressModal />, "md");
+    }
+  }, [showCustomModal]);
+
   return (
     <div className="rounded-xl border border-[#e5e7eb] bg-white p-6 shadow-sm">
-      <h1 className="text-2xl font-semibold text-[#111827]">Finance</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-[#111827]">Finance</h1>
+        <button
+          onClick={() => showCustomModal(<AddAddressModal />, "md")}
+          className="px-4 py-2 rounded-lg bg-[#5E2A8C] text-white hover:bg-[#4C1D95]"
+        >
+          Add address
+        </button>
+      </div>
       <p className="mt-2 text-[#6b7280]">Placeholder page.</p>
     </div>
   );

--- a/src/components/finance/add-address-modal.tsx
+++ b/src/components/finance/add-address-modal.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import useAddAddress from "@/hooks/use-add-address";
+import type { SupportedAssetSymbol, SupportedNetwork } from "@/types/address-types";
+import useModal from "@/hooks/useModal";
+
+type Option<T extends string> = { label: string; value: T };
+
+const assetOptions: Option<SupportedAssetSymbol>[] = [
+  { label: "USDC", value: "USDC" },
+  { label: "USDT", value: "USDT" },
+  { label: "ETH", value: "ETH" },
+  { label: "BTC", value: "BTC" },
+];
+
+const networkOptions: Option<SupportedNetwork>[] = [
+  { label: "Ethereum", value: "Ethereum" },
+  { label: "Polygon", value: "Polygon" },
+  { label: "Arbitrum", value: "Arbitrum" },
+  { label: "Optimism", value: "Optimism" },
+  { label: "Stellar", value: "Stellar" },
+];
+
+export default function AddAddressModal() {
+  const { hideModal } = useModal();
+  const {
+    values,
+    setAsset,
+    setNetwork,
+    setWalletAddress,
+    setWalletLabel,
+    canSubmit,
+    submitting,
+    submit,
+    reset,
+  } = useAddAddress();
+
+  const pasteFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) setWalletAddress(text);
+    } catch {
+      // Clipboard not available
+    }
+  };
+
+  const assetIcon: Record<SupportedAssetSymbol, string> = {
+    USDC: "/usdc.svg",
+    USDT: "/icons/usdt.svg",
+    ETH: "/icons/eth.svg",
+    BTC: "/bitcoin.svg",
+  };
+
+  const networkIcon: Record<SupportedNetwork, string> = {
+    Ethereum: "/icons/eth.svg",
+    Polygon: "/globe.svg", // placeholder icon in public
+    Arbitrum: "/globe.svg",
+    Optimism: "/globe.svg",
+    Stellar: "/stellar.svg",
+  };
+
+  return (
+    <div className="w-full max-w-xl">
+      {/* Header (back + title + close) */}
+      <div className="flex items-center justify-between pb-6">
+        <button
+          aria-label="Back"
+          onClick={hideModal}
+          className="p-2 rounded-md hover:bg-gray-100"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <path d="M15 18l-6-6 6-6" stroke="#111827" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        <h2 className="text-2xl font-semibold text-[#111827]">Add address</h2>
+        <button
+          aria-label="Close"
+          onClick={hideModal}
+          className="p-2 rounded-md hover:bg-gray-100"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <path d="M6 6l12 12M18 6L6 18" stroke="#111827" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        {/* Asset */}
+        <div className="flex flex-col gap-2">
+          <label className="text-sm text-[#111827]">Asset</label>
+          <div className="relative">
+            <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+              <img src={assetIcon[values.asset]} alt={values.asset} className="h-6 w-6" />
+              <span className="text-[#111827]">{values.asset}</span>
+            </div>
+            <select
+              className="appearance-none w-full rounded-xl bg-[#F3F4F6] pr-10 pl-14 py-4 text-transparent"
+              value={values.asset}
+              onChange={(e) => setAsset(e.target.value as SupportedAssetSymbol)}
+            >
+              {assetOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[#6b7280]">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+          </div>
+        </div>
+
+        {/* Network */}
+        <div className="flex flex-col gap-2">
+          <label className="text-sm text-[#111827]">Network</label>
+          <div className="relative">
+            <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+              <img src={networkIcon[values.network]} alt={values.network} className="h-6 w-6" />
+              <span className="text-[#111827]">{values.network}</span>
+            </div>
+            <select
+              className="appearance-none w-full rounded-xl bg-[#F3F4F6] pr-10 pl-14 py-4 text-transparent"
+              value={values.network}
+              onChange={(e) => setNetwork(e.target.value as SupportedNetwork)}
+            >
+              {networkOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[#6b7280]">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+          </div>
+        </div>
+
+        {/* Wallet address */}
+        <div className="flex flex-col gap-2">
+          <label className="text-sm text-[#111827]">Wallet address</label>
+          <div className="relative">
+            <input
+              placeholder="Paste or scan address"
+              className="w-full rounded-xl bg-[#F3F4F6] pr-28 pl-4 py-4 text-[#111827] placeholder:text-[#9CA3AF]"
+              value={values.walletAddress}
+              onChange={(e) => setWalletAddress(e.target.value)}
+            />
+            <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={pasteFromClipboard}
+                className="px-3 py-1 rounded-lg border border-[#E5E7EB] text-[#111827] bg-white hover:bg-gray-50"
+              >
+                Paste
+              </button>
+              <button
+                type="button"
+                onClick={() => {/* Integrate QR scanner here */}}
+                className="p-2 rounded-lg bg-white border border-[#E5E7EB] hover:bg-gray-50"
+                aria-label="Scan address"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                  <path d="M7 3H5a2 2 0 0 0-2 2v2M17 3h2a2 2 0 0 1 2 2v2M7 21H5a2 2 0 0 1-2-2v-2M19 21a2 2 0 0 0 2-2v-2" stroke="#6B7280" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Wallet label */}
+        <div className="flex flex-col gap-2">
+          <label className="text-sm text-[#111827]">Wallet label</label>
+          <input
+            placeholder="--"
+            className="w-full rounded-xl bg-[#F3F4F6] px-4 py-4 text-[#111827] placeholder:text-[#9CA3AF]"
+            value={values.walletLabel}
+            onChange={(e) => setWalletLabel(e.target.value)}
+          />
+        </div>
+
+        {/* Primary action */}
+        <div className="pt-2">
+          <button
+            disabled={!canSubmit || submitting}
+            onClick={async () => {
+              await submit();
+              hideModal();
+            }}
+            className="w-full px-6 py-4 rounded-xl bg-[#5E2A8C] text-white text-base font-medium hover:bg-[#4C1D95] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "Creating..." : "Create address"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -57,11 +57,11 @@ const Modal = () => {
       onClick={handleBackdropClick}
     >
       <div
-        className={`relative bg-white rounded-lg shadow-xl w-full ${sizeClasses[size]} max-h-[90vh] overflow-hidden`}
+        className={`relative bg-white rounded-lg shadow-xl w-full ${sizeClasses[size]}`}
       >
         {/* Header */}
         {(title || showCloseButton) && (
-          <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-between p-6">
             {title && (
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                 {title}
@@ -91,13 +91,13 @@ const Modal = () => {
         )}
 
         {/* Content */}
-        <div className="p-6 overflow-y-auto max-h-[70vh]">
+        <div className="p-6">
           {customComponent ? customComponent : content}
         </div>
 
         {/* Footer with buttons */}
         {showButtons && (
-          <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-end gap-3 p-6">
             {buttons.length > 0 ? (
               buttons.map((button, index) => (
                 <button

--- a/src/hooks/use-add-address.ts
+++ b/src/hooks/use-add-address.ts
@@ -1,0 +1,103 @@
+// Business logic for Add Address flow
+// All validations and submission are handled here
+
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type {
+  AddressBookItem,
+  AddressFormValues,
+  AddressValidationResult,
+  SupportedAssetSymbol,
+  SupportedNetwork,
+} from "@/types/address-types";
+
+const DEFAULT_VALUES: AddressFormValues = {
+  asset: "USDC",
+  network: "Ethereum",
+  walletAddress: "",
+  walletLabel: "",
+};
+
+function validateAddressFormat(
+  address: string,
+  network: SupportedNetwork
+): AddressValidationResult {
+  // Minimal format validation; extend with real libs per network
+  if (!address || address.trim().length < 8) {
+    return { isValid: false, message: "Address is too short" };
+  }
+  if (network === "Ethereum" && !/^0x[a-fA-F0-9]{8,}$/.test(address)) {
+    return { isValid: false, message: "Invalid Ethereum address format" };
+  }
+  return { isValid: true };
+}
+
+export default function useAddAddress(initial?: Partial<AddressFormValues>) {
+  const [values, setValues] = useState<AddressFormValues>({
+    ...DEFAULT_VALUES,
+    ...initial,
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = useMemo(() => {
+    const labelOk = values.walletLabel.trim().length > 0;
+    const addrValidation = validateAddressFormat(values.walletAddress, values.network);
+    return labelOk && addrValidation.isValid;
+  }, [values]);
+
+  const setAsset = useCallback((asset: SupportedAssetSymbol) => {
+    setValues((v) => ({ ...v, asset }));
+  }, []);
+
+  const setNetwork = useCallback((network: SupportedNetwork) => {
+    setValues((v) => ({ ...v, network }));
+  }, []);
+
+  const setWalletAddress = useCallback((walletAddress: string) => {
+    setValues((v) => ({ ...v, walletAddress }));
+  }, []);
+
+  const setWalletLabel = useCallback((walletLabel: string) => {
+    setValues((v) => ({ ...v, walletLabel }));
+  }, []);
+
+  const reset = useCallback(() => setValues(DEFAULT_VALUES), []);
+
+  const submit = useCallback(async (): Promise<AddressBookItem> => {
+    setSubmitting(true);
+    try {
+      const validation = validateAddressFormat(values.walletAddress, values.network);
+      if (!validation.isValid) {
+        throw new Error(validation.message || "Invalid address");
+      }
+
+      // Simulated persistence. Replace with API call when available
+      const newItem: AddressBookItem = {
+        id: crypto.randomUUID(),
+        createdAt: new Date().toISOString(),
+        ...values,
+      };
+
+      // TODO: integrate with backend/redux slice when available
+      return newItem;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [values]);
+
+  return {
+    values,
+    setAsset,
+    setNetwork,
+    setWalletAddress,
+    setWalletLabel,
+    canSubmit,
+    submitting,
+    reset,
+    submit,
+  };
+}
+
+
+

--- a/src/libs/store.ts
+++ b/src/libs/store.ts
@@ -6,6 +6,21 @@ export const Store = () => {
     reducer: {
       modal: modalReducer,
     },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        // We intentionally store React nodes and functions inside modal state
+        // for UI composition, so ignore serializability checks for this slice
+        serializableCheck: {
+          ignoredPaths: [
+            "modal.modalProps",
+          ],
+          ignoredActions: [
+            "modal/openModal",
+            "modal/closeModal",
+            "modal/resetModal",
+          ],
+        },
+      }),
   });
 };
 

--- a/src/types/address-types.ts
+++ b/src/types/address-types.ts
@@ -1,0 +1,31 @@
+// Address form domain types
+// NOTE: All components and hooks must import from this file for consistency
+
+export type SupportedAssetSymbol = "USDC" | "USDT" | "ETH" | "BTC";
+
+export type SupportedNetwork =
+  | "Ethereum"
+  | "Polygon"
+  | "Arbitrum"
+  | "Optimism"
+  | "Stellar";
+
+export interface AddressFormValues {
+  asset: SupportedAssetSymbol;
+  network: SupportedNetwork;
+  walletAddress: string;
+  walletLabel: string;
+}
+
+export interface AddressBookItem extends AddressFormValues {
+  id: string;
+  createdAt: string;
+}
+
+export interface AddressValidationResult {
+  isValid: boolean;
+  message?: string;
+}
+
+
+


### PR DESCRIPTION
## Description
Implements the Add Address form modal for the Finance page as specified in issue #110.

## Changes Made
- ✅ Created address form types and interfaces (`src/types/address-types.ts`)
- ✅ Implemented business logic hook (`src/hooks/use-add-address.ts`)
- ✅ Built modal component with form fields (`src/components/finance/add-address-modal.tsx`)
- ✅ Integrated modal in finance page with button and auto-open via query
- ✅ Fixed modal styling (removed border lines, proper purple color)
- ✅ Configured Redux store to handle non-serializable modal content

## Features
- Modal opens via button click or `?openAddAddress=true` query parameter
- Form validation for required fields
- Support for multiple assets (USDC, USDT, ETH, BTC) and networks
- Paste functionality for wallet addresses
- QR scanner button (placeholder for future implementation)
- Responsive design matching project design system

## Testing
- Navigate to `/app/finance` and click "Add address" button
- Or use `/app/finance?openAddAddress=true` for auto-open
- Fill form with test data and verify "Create address" button enables
<img width="1470" height="811" alt="Captura de pantalla 2025-10-03 a la(s) 10 19 59 a  m" src="https://github.com/user-attachments/assets/0357d905-5eea-4642-90da-ffc5e6310a9c" />

Closes #110